### PR TITLE
Fix: Warning background on light mode made visible

### DIFF
--- a/src/main/resources/GitHub_Light.xml
+++ b/src/main/resources/GitHub_Light.xml
@@ -1009,7 +1009,7 @@
         </option>
         <option name="WARNING_ATTRIBUTES">
             <value>
-                <option name="BACKGROUND" value="f0f0f0"/>
+                <option name="BACKGROUND" value="fbf3bd"/>
                 <option name="ERROR_STRIPE_COLOR" value="ebc700"/>
                 <option name="EFFECT_TYPE" value="1"/>
             </value>


### PR DESCRIPTION
# Description

Fix: Warning background on light mode made visible

## Type of change

- 🐛 bug fix
