### PR TITLE
added `skip ci` support for release workflow to avoid unwanted releases.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,7 @@ jobs:
   release:
     name: Publish Plugin
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'skip ci')"
     steps:
 
       # Setup Java 1.8 environment for the next steps


### PR DESCRIPTION
# Description

- added `skip ci` support for release workflow to avoid unwanted releases.

## Type of change

- 🔨 configuration / setup