### PR TITLE
Fix the tool window header and editor tab for GitHub Dark Contrast #196

### DIFF
--- a/src/main/resources/GitHub_Dark_High_Contrast.theme.json
+++ b/src/main/resources/GitHub_Dark_High_Contrast.theme.json
@@ -14,6 +14,10 @@
       "separatorForeground": "#30363d",
       "separatorColor": "#30363d",
       "lineSeparatorColor": "#30363d"
+    },
+    "ToolWindow.Header.inactiveBackground": "#0d1118",
+    "EditorTabs": {
+      "underlinedTabBackground": "#0d1116"
     }
   }
 }


### PR DESCRIPTION
# Description

Fixes #196

## Type of change

- 💅 styles