### PR TITLE
feat: improve colour consistency for dark contrast theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ## [Unreleased]
 
+## [1.2.3]
+- Fix: Fix popup window header for GitHub Dark Contrast.
+
 ## [1.2.2]
 
 - Fix: the tool window header and editor tab for GitHub Dark Contrast

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 
 pluginGroup = club.nutsoft
 pluginName = GitHub Theme
-pluginVersion = 1.2.2
+pluginVersion = 1.2.3
 
 # Plugin Verifier integration -> https://github.com/JetBrains/gradle-intellij-plugin#plugin-verifier-dsl
 # See https://jb.gg/intellij-platform-builds-list for available build versions.

--- a/src/main/resources/GitHub_Dark_High_Contrast.theme.json
+++ b/src/main/resources/GitHub_Dark_High_Contrast.theme.json
@@ -19,6 +19,24 @@
       "separatorColor": "#30363d",
       "lineSeparatorColor": "#30363d"
     },
+    "Button": {
+      "foreground": "#F0F6FC",
+      "loadingForeground": "#F0F6FC",
+      "startBackground": "#2A313C",
+      "endBackground": "#2A313C",
+      "startBorderColor": "#3D444D",
+      "endBorderColor": "#3D444D",
+      "focusedBorderColor": "#3D444D"
+    },
+    "NotificationsToolwindow": {
+      "newNotification": {
+        "background": "#30363d80",
+        "hoverBackground": "#30363d50"
+      },
+      "Notification": {
+        "hoverBackground": "#30363d50"
+      }
+    },
     "ToolWindow": {
       "background": "DarkBlue",
       "Header": {

--- a/src/main/resources/GitHub_Dark_High_Contrast.theme.json
+++ b/src/main/resources/GitHub_Dark_High_Contrast.theme.json
@@ -3,9 +3,13 @@
   "dark": true,
   "author": "Bhushan <bhushangaykawad@gmail.com>",
   "editorScheme": "/GitHub_Dark_High_Contrast.xml",
+  "colors": {
+    "Black": "#090c10",
+    "DarkBlue": "#0d1118"
+  },
   "ui": {
     "*": {
-      "background": "#090c10",
+      "background": "Black",
       "foreground": "#c9d1d9",
       "selectionBackground": "#173456",
       "selectionInactiveBackground": "#173456",
@@ -15,9 +19,20 @@
       "separatorColor": "#30363d",
       "lineSeparatorColor": "#30363d"
     },
-    "ToolWindow.Header.inactiveBackground": "#0d1118",
+    "ToolWindow": {
+      "background": "DarkBlue",
+      "Header": {
+        "background": "DarkBlue",
+        "inactiveBackground": "DarkBlue"
+      }
+    },
+    "Popup": {
+      "Header": {
+        "activeBackground": "DarkBlue"
+      }
+    },
     "EditorTabs": {
-      "underlinedTabBackground": "#0d1116"
+      "underlinedTabBackground": "Black"
     }
   }
 }


### PR DESCRIPTION
# Description

This PR updates styling for the Dark Default variant and is similar to #197 there are other spots in the UI that have similar behaviour. This PR mainly changes the way the Header and Tool window colors are declared for consistency then updates the color similar to that PR

<img width="513" alt="image" src="https://github.com/user-attachments/assets/8d2a7959-c9f2-4b19-81d6-2be09494fd6e" />

There are few other places I plan to make this change probably in follow up PR or here if I have time such as the bottoms and for some rows and other sporadic places

### Buttons
<img width="493" alt="image" src="https://github.com/user-attachments/assets/7129e182-e27b-4508-bd1a-e886b30865bc" />

### Checkboxes
<img width="85" alt="image" src="https://github.com/user-attachments/assets/c07961d1-0d72-4b65-8581-32b4d4bd82ac" />


## Type of change
- 💅 styles
